### PR TITLE
Fix memory trimming and config variable

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -34,8 +34,8 @@ storage = None
 youtube = Youtube()
 website = Website()
 
-memory = Memory(system_message=os.getenv('SYSTEM_MESSAGE'),memory_message_count=20)
-image_detail = system_message=os.getenv('IMAGE_DETAIL') or 'low' # low, high, or auto
+memory = Memory(system_message=os.getenv('SYSTEM_MESSAGE'), memory_message_count=20)
+image_detail = os.getenv('IMAGE_DETAIL') or 'low'  # low, high, or auto
 model_management = {}
 api_keys = {}
 

--- a/src/memory.py
+++ b/src/memory.py
@@ -28,7 +28,7 @@ class Memory(MemoryInterface):
     def _drop_message(self, user_id: str):
         if len(self.storage.get(user_id)) >= (self.memory_message_count + 1) * 2 + 1:
             self.storage[user_id] = [self.storage[user_id][0]] + self.storage[user_id][-(self.memory_message_count * 2):]
-        return self.storage.get(user_id)
+
     def change_system_message(self, user_id, system_message):
         self.system_messages[user_id] = system_message
         # self.remove(user_id)

--- a/src/memory.py
+++ b/src/memory.py
@@ -27,9 +27,8 @@ class Memory(MemoryInterface):
 
     def _drop_message(self, user_id: str):
         if len(self.storage.get(user_id)) >= (self.memory_message_count + 1) * 2 + 1:
-            return [self.storage[user_id][0]] + self.storage[user_id][-(self.memory_message_count * 2):]
+            self.storage[user_id] = [self.storage[user_id][0]] + self.storage[user_id][-(self.memory_message_count * 2):]
         return self.storage.get(user_id)
-
     def change_system_message(self, user_id, system_message):
         self.system_messages[user_id] = system_message
         # self.remove(user_id)


### PR DESCRIPTION
## Summary
- ensure Memory storage actually drops old messages
- remove stray variable assignment for IMAGE_DETAIL

## Testing
- `python3 -m py_compile src/memory.py api/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68404a98ac9c832baae6e50e46dc0b0e