### PR TITLE
Improve YouTube transcript fetch reliability

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -61,6 +61,9 @@ Import the ChatGPT bot to Line and start interacting with it by simply typing te
         4. Line Channel Access Token:
             - key: `LINE_CHANNEL_ACCESS_TOKEN`
             - value: `[obtained from step one]`
+        5. Set the retry count when fetching YouTube transcripts fails (optional):
+            - key: `YT_FETCH_RETRY`
+            - value: `3`
 2. Start running:
     1. Click on `Run` on the top.
     2. After successful, the right-side screen will display `Hello World`, and the **URL** on the top of the screen should be copied down.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@
         4. Line Channel Access Token:
             - key: `LINE_CHANNEL_ACCESS_TOKEN`
             - value: `[由步驟一取得]`
+        5. 設定 YouTube 字幕擷取失敗時的重試次數（可選）：
+            - key: `YT_FETCH_RETRY`
+            - value: `3`
 2. 開始執行
     1. 點擊上方的 `Run`
     2. 成功後右邊畫面會顯示 `Hello World`，並將畫面中上方的**網址複製**下來


### PR DESCRIPTION
## Summary
- add retry count configuration for `Youtube` service
- retry transcript fetch on XML parse errors
- document `YT_FETCH_RETRY` env variable

## Testing
- `python -m py_compile src/service/youtube.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d657fa74832b97f9e712fc9442a8